### PR TITLE
Replace debug prints with logger usage

### DIFF
--- a/src/components/evaluation/default_evaluation_component.py
+++ b/src/components/evaluation/default_evaluation_component.py
@@ -363,7 +363,12 @@ class CustomEvaluationCallback(TrainerCallback):
     ) -> None:
         """Fallback logging to console when WandB is not available."""
         for metric_name, value in metrics_to_log.items():
-            print(f"EVAL METRIC: {metric_name}={value} step={current_step}")
+            logger.info(
+                "EVAL METRIC: %s=%s step=%s",
+                metric_name,
+                value,
+                current_step,
+            )
 
     def on_train_begin(
         self,

--- a/src/components/reward/default_reward_component.py
+++ b/src/components/reward/default_reward_component.py
@@ -350,14 +350,14 @@ def check_numbers(
             match.group(1) if match and match.group(1) else None
         )
 
-        # Debug print, consider replacing with logger.debug
-        if i == 0:  # Print only for the first item for brevity
-            print(
+        if i == 0:  # Log only for the first item for brevity
+            logger.debug(
+                "%s Question:\n%s\nAnswer:\n%s\nResponse:\n%s\nExtracted:\n%s",
                 "*" * 20,
-                f"Question:\\n{question_content}",
-                f"\\nAnswer:\\n{true_answer_str}",
-                f"\\nResponse:\\n{response_str}",
-                f"\\nExtracted:\\n{extracted_guess_str}",
+                question_content,
+                true_answer_str,
+                response_str,
+                extracted_guess_str,
             )
 
         if extracted_guess_str is None:


### PR DESCRIPTION
## Summary
- replace a debug print in `default_reward_component.py` with `logger.debug`
- switch to using `logger.info` when printing metrics in `default_evaluation_component.py`

## Testing
- `isort src/components/reward/default_reward_component.py src/components/evaluation/default_evaluation_component.py`
- `black src/components/reward/default_reward_component.py src/components/evaluation/default_evaluation_component.py`

------
https://chatgpt.com/codex/tasks/task_e_68558022eafc8320b15ff521599d29c0